### PR TITLE
Add /config/environment.sh which can set environment variables

### DIFF
--- a/setup/nobody/start.sh
+++ b/setup/nobody/start.sh
@@ -12,6 +12,10 @@ export JENKINS_WEBROOT=--webroot=/var/cache/jenkins
 export JENKINS_PORT=--httpPort=8090
 export JENKINS_AJPPORT=--ajp13Port=-1
 export JENKINS_OPTS=
+
+# include user-defined environment variables if file exists
+FILE=/config/environment.sh && test -f $FILE && source $FILE
+
 export JENKINS_COMMAND_LINE="$JAVA $JAVA_ARGS $JAVA_OPTS -jar $JENKINS_WAR $JENKINS_WEBROOT $JENKINS_PORT $JENKINS_AJPPORT $JENKINS_OPTS"
 
 # run jenkins


### PR DESCRIPTION
Fix for http://lime-technology.com/forum/index.php?topic=45839.msg441207#msg441207

This will allow changing JVM  options, making jenkins run in a subdirectory and other advanced settings as described here: https://wiki.jenkins-ci.org/display/JENKINS/Features+controlled+by+system+properties
