### PR TITLE
Add install for ADDITIONAL_PKGS env var to start script

### DIFF
--- a/run/nobody/start.sh
+++ b/run/nobody/start.sh
@@ -10,5 +10,11 @@ export JENKINS_WEBROOT=--webroot=/var/cache/jenkins
 export JENKINS_PORT=--httpPort=8090
 export JENKINS_COMMAND_LINE="${JAVA} ${JAVA_ARGS} ${JAVA_OPTS} -jar ${JENKINS_WAR} ${JENKINS_WEBROOT} ${JENKINS_PORT} ${JENKINS_OPTS}"
 
+# install additional packages using pacman if specified
+if [[ ! -z "${ADDITIONAL_PKGS}" ]]; then
+	echo "[info] Installing additional packages: ${ADDITIONAL_PKGS}"
+	pacman -S --needed $ADDITIONAL_PKGS --noconfirm
+fi
+
 # run jenkins
 /bin/sh -c 'eval "${JENKINS_COMMAND_LINE}"'


### PR DESCRIPTION
I have a pretty specific (you might say niche) need to have additional packages installed, so much so that I drag my feet to update the Docker container as often as I should (don't wanna have to ssh in to manually install it after each update).

This way, I can specify an env var and it's done for me automatically every time the startup script runs.

[Here's the other PR that updates the Unraid docker template for this image.](https://github.com/binhex/docker-templates/pull/37)

I can update the README to include this param?

Tested locally by building my own image and creating containers from it - specified `-e ADDITIONAL_PKGS='npm vim'` to the `docker run` command and both were installed after I created a new container.